### PR TITLE
actions: push origin position to tag stack so <C-t> returns properly

### DIFF
--- a/lua/wayfinder/actions.lua
+++ b/lua/wayfinder/actions.lua
@@ -201,6 +201,17 @@ function M.click_jump()
   M.jump()
 end
 
+local function push_tagstack(win, tagname)
+  if not win or not vim.api.nvim_win_is_valid(win) then
+    return
+  end
+  local bufnr = vim.api.nvim_win_get_buf(win)
+  local cursor = vim.api.nvim_win_get_cursor(win)
+  local from = { bufnr, cursor[1], cursor[2] + 1, 0 }
+  local items = { { tagname = tagname ~= "" and tagname or "wayfinder", from = from } }
+  pcall(vim.fn.settagstack, win, { items = items }, "t")
+end
+
 local function open_item(item, opener)
   local session = current()
   if not session or not item or not item.path then
@@ -208,6 +219,11 @@ local function open_item(item, opener)
   end
 
   local target_win = session.origin_win
+  local tagname = (session.symbol and session.symbol.text) or session.subject or ""
+  if opener == "edit" or opener == nil then
+    push_tagstack(target_win, tagname)
+  end
+
   layout.close()
   if target_win and vim.api.nvim_win_is_valid(target_win) then
     vim.api.nvim_set_current_win(target_win)


### PR DESCRIPTION
When we 'enter' a new view, we aren't saving the origin position on the tag stack. 
This patch captures the origin window's buffer + cursor before closing the wayfinder UI, pushes a { tagname, from } entry so commands like <C-t> works. 

been enjoying using this plugin, thanks for the work.