### PR TITLE
fix(layout): default inner pane border to none

### DIFF
--- a/lua/wayfinder/layout.lua
+++ b/lua/wayfinder/layout.lua
@@ -153,6 +153,11 @@ local function create_window(bufnr, config_opts, opts)
   if opts.zindex then
     config_opts.zindex = opts.zindex
   end
+  -- Opt out of vim.o.winborder (Neovim 0.11+) for inner panes that don't
+  -- explicitly request a border. The outer border window sets its own.
+  if config_opts.border == nil then
+    config_opts.border = "none"
+  end
 
   local winid = vim.api.nvim_open_win(bufnr, false, config_opts)
   vim.wo[winid].winhighlight = table.concat({


### PR DESCRIPTION
## Summary

Inner floats (top header, facet, list, preview, dividers, bottom) don't pass `border` to `nvim_open_win`, so they inherit `vim.o.winborder` (Neovim 0.11+). With `winborder = "rounded"` set globally, every pane renders its own rounded border, breaking the intended seamless 3-pane layout and visibly truncating the top header at facet/list boundaries.

<img width="1881" height="425" alt="Screenshot 2026-04-30 at 10 54 40" src="https://github.com/user-attachments/assets/557019af-8846-40f2-bce4-0fca977be4cc" />

## Repro

Save as `repro.lua` and run `nvim -u repro.lua repro.lua`, then `:Wayfinder` on a symbol:

```lua
vim.o.winborder = "rounded"

vim.pack.add({
  { src = "https://github.com/error311/wayfinder.nvim" },
}, { load = true })

require("wayfinder").setup({})
```

Headless probe of the resulting float configs (before this fix):

```
winborder=rounded
border:  border=rounded (inherited)
top:     border=rounded (inherited)
facet:   border=rounded (inherited)
list:    border=rounded (inherited)
preview: border=rounded (inherited)
```

After this fix:

```
winborder=rounded
border:  border=rounded   ← outer frame, layout.border honored
top:     border=none
facet:   border=none
list:    border=none
preview: border=none
bottom:  border=none
```

## Fix

Default `config_opts.border = "none"` inside `create_window` when the caller doesn't pass one. The outer border window already passes `layout.border` explicitly, so it's unaffected. Robust against any user `vim.o.winborder` setting.

## Test plan

- [x] Headless `nvim_win_get_config` confirms inner panes are `border = "none"` and outer remains rounded
- [x] Visual sanity: `:Wayfinder` matches `docs/screenshots/overview.png` with `winborder = "rounded"` set
- [x] Visual sanity with `winborder = ""` / unset (no regression for users without the global default)